### PR TITLE
Suggestion :: Keep doc in text

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     
     <ul class="nav navbar-nav">
                         <li>
-    <a href="/1.x/">1.x</a>
+    <a href="/1.x/">1.x Doc</a>
     
     <ul class="dropdown-menu">
                         <li>


### PR DESCRIPTION
I find it hard to see the documentation link after landing on the home page. Probably adding a text `Doc` may help for people like me.